### PR TITLE
Update 10.md

### DIFF
--- a/resources/text/10.md
+++ b/resources/text/10.md
@@ -118,7 +118,7 @@ Here are further examples of the use of `def`:
 
 {{ 1.1.2.3.clj }}
 
-`Def` is our language's simplest means of abstraction, for it allows us to
+`def` is our language's simplest means of abstraction, for it allows us to
 use simple names to refer to the results of compound operations, such as the
 `circumference` computed above. In general, computational objects may have
 very complex structures, and it would be extremely inconvenient to have to
@@ -210,7 +210,7 @@ the purpose of the `def` is precisely to associate `x` with a value. (That
 is, `(def x 3)` is not a combination.)
 
 Such exceptions to the general evaluation rule are called _special forms_.
-`Def` is the only example of a special form that we have seen so far, but
+`def` is the only example of a special form that we have seen so far, but
 we will meet others shortly. Each special form has its own evaluation rule.
 The various kinds of expressions (each with its associated evaluation rule)
 constitute the syntax of the programming language. In comparison with most


### PR DESCRIPTION
Fixed capitalization typo from Def -> def to be more consistent with SICP's capitalization of `define` throughout the text.
